### PR TITLE
fix : avoid reload src again while uses videojs-hlsjs-plugin

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -515,13 +515,15 @@ PlayerWrapper.prototype.onAdStart = function() {
  */
 PlayerWrapper.prototype.onAllAdsCompleted = function() {
   if (this.contentComplete == true) {
-    if (this.h5Player.src != this.contentSource) {
-      // Avoid setted autoplay after the post-roll
-      this.vjsPlayer.autoplay(false);
-      this.vjsPlayer.src({
-        src: this.contentSource,
-        type: this.contentSourceType,
-      });
+    if ((typeof this.h5Player.src === 'string') && (this.h5Player.src.indexOf('blob:') === -1) ) {
+      if (this.h5Player.src != this.contentSource) {
+        // Avoid setted autoplay after the post-roll
+        this.vjsPlayer.autoplay(false);
+        this.vjsPlayer.src({
+          src: this.contentSource,
+          type: this.contentSourceType,
+        });
+      }
     }
     this.controller.onContentAndAdsCompleted();
   }


### PR DESCRIPTION
videojs-hlsjs-plugin uses dailyMotion hlsjs-engine. after onAllAdsCompleted event we must avoid reload src for making player more reliable. In videojs-hlsjs-plugin, this.h5Player.src contains string "blob:" prefix. We cannot compare its-value with this.contentSource, because it's "always" different.

https://stackoverflow.com/questions/30864573/what-is-a-blob-url-and-why-it-is-used